### PR TITLE
NetworkApi 생성 시, 요청 파라미터로 인증 키 전달 

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,7 +14,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.NBDream"
-        tools:targetApi="31">
+        tools:targetApi="31"
+        android:networkSecurityConfig="@xml/network_security_config">
         <activity
             android:name=".ui.MainActivity"
             android:exported="true"

--- a/app/src/main/java/kr/co/wdtt/nbdream/data/remote/api/NetworkApi.kt
+++ b/app/src/main/java/kr/co/wdtt/nbdream/data/remote/api/NetworkApi.kt
@@ -1,5 +1,6 @@
 package kr.co.wdtt.nbdream.data.remote.api
 
+import android.util.Log
 import kr.co.wdtt.nbdream.data.remote.model.ApiResult
 import kr.co.wdtt.nbdream.data.remote.model.NetWorkRequestInfo
 import kr.co.wdtt.nbdream.data.remote.retrofit.NetWorkRequestFactory
@@ -8,14 +9,20 @@ class NetworkApi private constructor(
     private val netWorkRequestFactory: NetWorkRequestFactory,
     private val headAuth: String,
     private val headKey: String,
+    private val paramAuth: String,
+    private val paramKey: String,
 ) {
     companion object {
         fun create(
             netWorkRequestFactory: NetWorkRequestFactory,
-            headAuth: String,
-            headKey: String,
-        ) = NetworkApi(netWorkRequestFactory, headAuth, headKey)
-
+            headAuth: String = "",
+            headKey: String = "",
+            paramAuth: String = "",
+            paramKey: String = "",
+        ): NetworkApi {
+            Log.d("NetworkApi", "create) headAuth : $headAuth, headKey : $headKey, paramAuth : $paramAuth, paramKey : $paramKey")
+            return NetworkApi(netWorkRequestFactory, headAuth, headKey, paramAuth, paramKey)
+        }
     }
 
     internal suspend inline fun <reified T : Any> sendRequest(
@@ -23,10 +30,25 @@ class NetworkApi private constructor(
         queryMap: Map<String, String>? = null,
     ): ApiResult<T> =
         netWorkRequestFactory.create(
-            url = url?: "",
+            url = url ?: "",
             requestInfo = NetWorkRequestInfo.Builder()
-                .withHeaders(mapOf(headAuth to headKey))
-                .withQueryMap(queryMap ?: mapOf())
+                .apply {
+                    if (headAuth.isNotEmpty() && headKey.isNotEmpty()) {
+                        withHeaders(mapOf(headAuth to headKey))
+                    }
+                }
+                .apply {
+                    withQueryMap(
+                        (queryMap ?: mapOf())
+                            .toMutableMap()
+                            .apply {
+                                if (paramAuth.isNotEmpty() && paramKey.isNotEmpty())
+                                    put(paramAuth, paramKey)
+
+                                Log.d("NetworkApi", "queryMap : $this")
+                            }
+                    )
+                }
                 .build(),
             type = T::class
         )

--- a/app/src/main/java/kr/co/wdtt/nbdream/data/remote/retrofit/NetworkFactoryManager.kt
+++ b/app/src/main/java/kr/co/wdtt/nbdream/data/remote/retrofit/NetworkFactoryManager.kt
@@ -3,5 +3,11 @@ package kr.co.wdtt.nbdream.data.remote.retrofit
 import kr.co.wdtt.nbdream.data.remote.api.NetworkApi
 
 interface NetworkFactoryManager {
-    fun create(baseUrl: String, headAuth: String, headKey: String): NetworkApi
+    fun create(
+        baseUrl: String,
+        headAuth: String = "",
+        headKey: String = "",
+        paramAuth: String = "",
+        paramKey: String = ""
+    ): NetworkApi
 }

--- a/app/src/main/java/kr/co/wdtt/nbdream/data/remote/retrofit/NetworkFactoryManagerImpl.kt
+++ b/app/src/main/java/kr/co/wdtt/nbdream/data/remote/retrofit/NetworkFactoryManagerImpl.kt
@@ -22,11 +22,13 @@ class NetworkFactoryManagerImpl @Inject constructor(
         baseUrl: String,
         headAuth: String,
         headKey: String,
+        paramAuth: String,
+        paramKey: String
     ) = createRetrofit(baseUrl, okHttpClient).create(NetworkService::class.java)
         .let { networkService ->
             NetWorkRequestFactory.create(networkService, headerParser).let { factory ->
                 NetworkApi.create(
-                    factory, headAuth, headKey
+                    factory, headAuth, headKey, paramAuth, paramKey
                 )
             }
         }

--- a/app/src/main/java/kr/co/wdtt/nbdream/data/remote/retrofit/StringConverterFactory.kt
+++ b/app/src/main/java/kr/co/wdtt/nbdream/data/remote/retrofit/StringConverterFactory.kt
@@ -1,5 +1,6 @@
 package kr.co.wdtt.nbdream.data.remote.retrofit
 
+import android.util.Log
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.serializer
@@ -39,18 +40,20 @@ class StringConverterFactory : Converter.Factory() {
             super.responseBodyConverter(type, annotations, retrofit)
         }
 
-    inner class ResponseBodyConverter : Converter<ResponseBody, String> {
-        override fun convert(p0: ResponseBody) =
-            p0.string()
-
-    }
-
     inner class RequestBodyConverter<T>(private val serializer: KSerializer<T>) :
         Converter<T, RequestBody> {
         override fun convert(p0: T): RequestBody {
             val jsonString = json.encodeToString(serializer, p0)
             return jsonString.toRequestBody(MEDIA_TYPE)
         }
-
     }
+
+    inner class ResponseBodyConverter : Converter<ResponseBody, String> {
+        override fun convert(p0: ResponseBody):String{
+            Log.d("StringConverterFactory", p0.string())
+            return p0.string()
+        }
+    }
+
+
 }

--- a/app/src/main/java/kr/co/wdtt/nbdream/data/repository/FarmWorkRepositoryImpl.kt
+++ b/app/src/main/java/kr/co/wdtt/nbdream/data/repository/FarmWorkRepositoryImpl.kt
@@ -15,7 +15,7 @@ internal class FarmWorkRepositoryImpl @Inject constructor(
     private val mapper: FarmWorkMapper
 ) : FarmWorkRepository {
     companion object {
-        const val BASE_URL = "http://api.nongsaro.go.kr/service/farmWorkingPlanNew"
+        const val BASE_URL = "http://api.nongsaro.go.kr/service/farmWorkingPlanNew/"
         const val FARM_WORK = "workScheduleEraInfoJsonLst"
         const val HEAD_AUTH = "apiKey"
         const val HEAD_KEY = BuildConfig.NONGSARO_API_KEY

--- a/app/src/main/java/kr/co/wdtt/nbdream/data/repository/FarmWorkRepositoryImpl.kt
+++ b/app/src/main/java/kr/co/wdtt/nbdream/data/repository/FarmWorkRepositoryImpl.kt
@@ -17,16 +17,16 @@ internal class FarmWorkRepositoryImpl @Inject constructor(
     companion object {
         const val BASE_URL = "http://api.nongsaro.go.kr/service/farmWorkingPlanNew/"
         const val FARM_WORK = "workScheduleEraInfoJsonLst"
-        const val HEAD_AUTH = "apiKey"
-        const val HEAD_KEY = BuildConfig.NONGSARO_API_KEY
+        const val PARAM_AUTH = "apiKey"
+        const val PARAM_KEY = BuildConfig.NONGSARO_API_KEY
     }
 
     private val queryMap = mutableMapOf<String, String>()
 
     private val networkApi = network.create(
-        BASE_URL,
-        HEAD_AUTH,
-        HEAD_KEY
+        baseUrl = BASE_URL,
+        paramAuth = PARAM_AUTH,
+        paramKey = PARAM_KEY
     )
 
     override suspend fun getFarmWorkByCrop(cropCode: String): Flow<EntityWrapper<List<FarmWorkEntity>>> =

--- a/app/src/main/java/kr/co/wdtt/nbdream/data/repository/WeatherForecastRepositoryImpl.kt
+++ b/app/src/main/java/kr/co/wdtt/nbdream/data/repository/WeatherForecastRepositoryImpl.kt
@@ -28,9 +28,9 @@ internal class WeatherForecastRepositoryImpl @Inject constructor(
     )
 
     private val networkApi = network.create(
-        BASE_URL,
-        HEAD_AUTH,
-        HEAD_KEY
+        baseUrl = BASE_URL,
+        headAuth = HEAD_AUTH,
+        headKey = HEAD_KEY
     )
 
     override suspend fun getDayWeatherForecast(

--- a/app/src/main/java/kr/co/wdtt/nbdream/domain/usecase/GetFarmWorkUseCase.kt
+++ b/app/src/main/java/kr/co/wdtt/nbdream/domain/usecase/GetFarmWorkUseCase.kt
@@ -1,0 +1,11 @@
+package kr.co.wdtt.nbdream.domain.usecase
+
+import kr.co.wdtt.nbdream.domain.repository.FarmWorkRepository
+import javax.inject.Inject
+
+class GetFarmWorkUseCase @Inject constructor(
+    private val farmWorkRepository: FarmWorkRepository
+){
+    suspend operator fun invoke(cropCode:String) =
+        farmWorkRepository.getFarmWorkByCrop(cropCode)
+}

--- a/app/src/main/java/kr/co/wdtt/nbdream/ui/DreamApp.kt
+++ b/app/src/main/java/kr/co/wdtt/nbdream/ui/DreamApp.kt
@@ -1,9 +1,11 @@
 package kr.co.wdtt.nbdream.ui
 
 import androidx.compose.runtime.Composable
+import kr.co.wdtt.nbdream.ui.calendar.CalendarScreen
 import kr.co.wdtt.nbdream.ui.home.HomeRoute
 
 @Composable
 fun DreamApp(){
-    HomeRoute()
+    //HomeRoute()
+    CalendarScreen()
 }

--- a/app/src/main/java/kr/co/wdtt/nbdream/ui/calendar/CalendarScreen.kt
+++ b/app/src/main/java/kr/co/wdtt/nbdream/ui/calendar/CalendarScreen.kt
@@ -1,0 +1,24 @@
+package kr.co.wdtt.nbdream.ui.calendar
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+
+@Composable
+fun CalendarScreen(
+    viewModel: CalendarViewModel = hiltViewModel()
+) {
+    Scaffold(
+        modifier = Modifier.fillMaxSize()
+    ){ innerPadding ->
+        Surface(
+            modifier = Modifier.padding(innerPadding)) {
+            Text("Calendar Screen")
+        }
+    }
+}

--- a/app/src/main/java/kr/co/wdtt/nbdream/ui/calendar/CalendarViewModel.kt
+++ b/app/src/main/java/kr/co/wdtt/nbdream/ui/calendar/CalendarViewModel.kt
@@ -1,0 +1,31 @@
+package kr.co.wdtt.nbdream.ui.calendar
+
+import android.util.Log
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import kr.co.wdtt.core.ui.base.BaseViewModel
+import kr.co.wdtt.core.ui.base.CustomErrorType
+import kr.co.wdtt.nbdream.domain.usecase.GetFarmWorkUseCase
+import javax.inject.Inject
+
+@HiltViewModel
+class CalendarViewModel @Inject constructor(
+    private val getFarmWorkUseCase:GetFarmWorkUseCase
+) : BaseViewModel() {
+    private val TAG = this@CalendarViewModel::class.java.simpleName
+
+    override suspend fun onError(errorType: CustomErrorType) {
+        //TODO("Not yet implemented")
+    }
+    init {
+        viewModelScopeEH.launch {
+            farmWorkApiTest()
+        }
+    }
+
+    private suspend fun farmWorkApiTest() {
+        getFarmWorkUseCase.invoke("30697").collect{
+            Log.d(TAG, "$it")
+        }
+    }
+}

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">api.nongsaro.go.kr</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
## Issue
- #26 

## Overview
- 농사로 농작업일정 API 호출 시, 서비스 인증 키를 Header가 아닌 요청 파라미터를 통해 전달해야 함
  - NetworkApi 클래스 파라미터에 paramAuth, paramKey 필드 추가
  - NetworkRequestInfo를 Build할 때 queryMap에 추가되도록 함

## To Reviewers 
- headAuth, headKey, paramAuth, paramKey 필드를 default 값이 ""인 String 타입으로 정의했는데, 
default 값이 null인 nullable String 타입으로 정의하는 게 더 나을까요?
