### PR TITLE
Feat: AccountBookRepository 인터페이스와 구현체 추가

### DIFF
--- a/app/src/main/java/kr/co/wdtt/nbdream/data/di/RepositoryModule.kt
+++ b/app/src/main/java/kr/co/wdtt/nbdream/data/di/RepositoryModule.kt
@@ -4,8 +4,10 @@ import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import kr.co.wdtt.nbdream.data.repository.AccountBookRepositoryImpl
 import kr.co.wdtt.nbdream.data.repository.FarmWorkRepositoryImpl
 import kr.co.wdtt.nbdream.data.repository.WeatherForecastRepositoryImpl
+import kr.co.wdtt.nbdream.domain.repository.AccountBookRepository
 import kr.co.wdtt.nbdream.domain.repository.FarmWorkRepository
 import kr.co.wdtt.nbdream.domain.repository.WeatherForecastRepository
 import javax.inject.Singleton
@@ -19,5 +21,7 @@ internal abstract class RepositoryModule {
     @Singleton
     @Binds
     abstract fun bindsCalFarmWorkRepository(repositoryImpl: FarmWorkRepositoryImpl): FarmWorkRepository
-
+    @Singleton
+    @Binds
+    abstract fun bindsAccountBookRepository(repositoryImpl: AccountBookRepositoryImpl): AccountBookRepository
 }

--- a/app/src/main/java/kr/co/wdtt/nbdream/data/mapper/AccountBookMapper.kt
+++ b/app/src/main/java/kr/co/wdtt/nbdream/data/mapper/AccountBookMapper.kt
@@ -1,0 +1,39 @@
+package kr.co.wdtt.nbdream.data.mapper
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kr.co.wdtt.core.domain.base.BaseMapper
+import kr.co.wdtt.nbdream.data.remote.dto.AccountBookResponse
+import kr.co.wdtt.nbdream.domain.entity.AccountBookEntity
+
+class AccountBookMapper : BaseMapper<AccountBookResponse, List<AccountBookEntity>>() {
+    override fun getSuccess(data: AccountBookResponse?, extra: Any?): Flow<EntityWrapper.Success<List<AccountBookEntity>>> {
+        return flow {
+            data?.let { response ->
+                val accountBooks = response.response.body.items.map { item ->
+                    AccountBookEntity(
+                        id = item.id,
+                        title = item.title,
+                        category = item.category,
+                        imageUrl = item.imageUrl,
+                        registerDateTime = item.registerDateTime,
+                        year = item.year,
+                        month = item.month,
+                        day = item.day,
+                        dayName = item.dayName,
+                        revenue = item.revenue,
+                        expense = item.expense,
+                        totalRevenue = item.totalRevenue,
+                        totalExpense = item.totalExpense,
+                        totalCost = item.totalCost
+                    )
+                }
+                emit(EntityWrapper.Success(accountBooks))
+            } ?: emit(EntityWrapper.Success(emptyList()))
+        }
+    }
+
+    override fun getFailure(error: Throwable): Flow<EntityWrapper.Fail<List<AccountBookEntity>>> {
+        return flow { emit(EntityWrapper.Fail(error)) }
+    }
+}

--- a/app/src/main/java/kr/co/wdtt/nbdream/data/remote/dto/AccountBookResponse.kt
+++ b/app/src/main/java/kr/co/wdtt/nbdream/data/remote/dto/AccountBookResponse.kt
@@ -1,0 +1,43 @@
+package kr.co.wdtt.nbdream.data.remote.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AccountBookResponse(
+    val response: Response
+) {
+    @Serializable
+    data class Response(
+        val header: Header,
+        val body: Body,
+    ) {
+        @Serializable
+        data class Header(
+            val resultCode: String,
+            val resultMsg: String,
+        )
+
+        @Serializable
+        data class Body(
+            val items: List<Item>
+        ) {
+            @Serializable
+            data class Item(
+                val id: String,
+                val title: String,
+                val category: String,
+                val imageUrl: List<String>,
+                val registerDateTime: String?,
+                val year: Int?,
+                val month: Int?,
+                val day: Int?,
+                val dayName: String?,
+                val revenue: Long?,
+                val expense: Long?,
+                val totalRevenue: Long?,
+                val totalExpense: Long?,
+                val totalCost: Long?
+            )
+        }
+    }
+}

--- a/app/src/main/java/kr/co/wdtt/nbdream/data/repository/AccountBookRepositoryImpl.kt
+++ b/app/src/main/java/kr/co/wdtt/nbdream/data/repository/AccountBookRepositoryImpl.kt
@@ -1,0 +1,139 @@
+package kr.co.wdtt.nbdream.data.repository
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kr.co.wdtt.nbdream.data.mapper.AccountBookMapper
+import kr.co.wdtt.nbdream.data.mapper.EntityWrapper
+import kr.co.wdtt.nbdream.data.remote.dto.AccountBookResponse
+import kr.co.wdtt.nbdream.data.remote.model.ApiResponse
+import kr.co.wdtt.nbdream.data.remote.retrofit.NetworkFactoryManager
+import kr.co.wdtt.nbdream.domain.entity.AccountBookEntity
+import kr.co.wdtt.nbdream.domain.repository.AccountBookRepository
+import javax.inject.Inject
+
+
+internal class AccountBookRepositoryImpl @Inject constructor(
+    network: NetworkFactoryManager,
+    private val mapper: AccountBookMapper
+) : AccountBookRepository {
+    companion object {
+        const val BASE_URL = "base_url"
+        const val HEAD_AUTH = "head_auth"
+        const val HEAD_KEY = "head_key"
+    }
+
+    private val queryMap = mutableMapOf<String, String>()
+
+    private val networkApi = network.create(
+        BASE_URL,
+        HEAD_AUTH,
+        HEAD_KEY
+    )
+
+    override suspend fun getAccountBooks(
+        userId: String,
+        startDate: String,
+        endDate: String,
+        type: String,
+        sortOrder: String,
+        category: String
+    ): Flow<List<AccountBookEntity>> {
+        queryMap.clear()
+        queryMap.putAll(
+            mapOf(
+                "userId" to userId,
+                "startDate" to startDate,
+                "endDate" to endDate,
+                "type" to type,
+                "sortOrder" to sortOrder,
+                "category" to category
+            )
+        )
+        val apiResult = networkApi.sendRequest<AccountBookResponse>(
+            url = "get_url",
+            queryMap = queryMap
+        )
+        return mapper.mapFromResult(apiResult).map {
+            when (it) {
+                is EntityWrapper.Success -> it.data
+                is EntityWrapper.Fail -> throw IllegalStateException("Get account book failed: ${it.throwable?.message}")
+            }
+        }
+    }
+
+    override suspend fun createAccountBook(accountBook: AccountBookEntity): AccountBookEntity {
+        queryMap.clear()
+        queryMap.putAll(
+            mapOf(
+                "title" to accountBook.title,
+                "category" to accountBook.category,
+                "imageUrl" to accountBook.imageUrl.joinToString(separator = ","),
+                "registerDateTime" to (accountBook.registerDateTime ?: ""),
+                "year" to (accountBook.year?.toString() ?: ""),
+                "month" to (accountBook.month?.toString() ?: ""),
+                "day" to (accountBook.day?.toString() ?: ""),
+                "dayName" to (accountBook.dayName ?: ""),
+                "revenue" to (accountBook.revenue?.toString() ?: ""),
+                "expense" to (accountBook.expense?.toString() ?: ""),
+                "totalRevenue" to (accountBook.totalRevenue?.toString() ?: ""),
+                "totalExpense" to (accountBook.totalExpense?.toString() ?: ""),
+                "totalCost" to (accountBook.totalCost?.toString() ?: "")
+            )
+        )
+
+        val apiResult = networkApi.sendRequest<AccountBookEntity>(
+            url = "create_url",
+            queryMap = queryMap
+        )
+        return when (val response = apiResult.response) {
+            is ApiResponse.Success -> response.data
+            is ApiResponse.Fail -> throw IllegalStateException("Create account book failed: ${response.error.message}")
+        }
+    }
+
+    override suspend fun updateAccountBook(
+        id: String,
+        accountBook: AccountBookEntity
+    ): AccountBookEntity {
+        queryMap.clear()
+        queryMap.putAll(
+            mapOf(
+                "id" to id,
+                "title" to accountBook.title,
+                "category" to accountBook.category,
+                "imageUrl" to accountBook.imageUrl.joinToString(separator = ","),
+                "registerDateTime" to (accountBook.registerDateTime ?: ""),
+                "year" to (accountBook.year?.toString() ?: ""),
+                "month" to (accountBook.month?.toString() ?: ""),
+                "day" to (accountBook.day?.toString() ?: ""),
+                "dayName" to (accountBook.dayName ?: ""),
+                "revenue" to (accountBook.revenue?.toString() ?: ""),
+                "expense" to (accountBook.expense?.toString() ?: ""),
+                "totalRevenue" to (accountBook.totalRevenue?.toString() ?: ""),
+                "totalExpense" to (accountBook.totalExpense?.toString() ?: ""),
+                "totalCost" to (accountBook.totalCost?.toString() ?: "")
+            )
+        )
+
+        val apiResult = networkApi.sendRequest<AccountBookEntity>(
+            url = "update_url",
+            queryMap = queryMap
+        )
+        return when (val response = apiResult.response) {
+            is ApiResponse.Success -> response.data
+            is ApiResponse.Fail -> throw IllegalStateException("Update account book failed: ${response.error.message}")
+        }
+    }
+
+    override suspend fun deleteAccountBook(id: String) {
+        queryMap.clear()
+        queryMap.putAll(mapOf("id" to id))
+
+        networkApi.sendRequest<Unit>(
+            url = "delete_url",
+            queryMap = queryMap
+        )
+    }
+
+
+}

--- a/app/src/main/java/kr/co/wdtt/nbdream/domain/entity/AccountBookEntity.kt
+++ b/app/src/main/java/kr/co/wdtt/nbdream/domain/entity/AccountBookEntity.kt
@@ -1,19 +1,20 @@
 package kr.co.wdtt.nbdream.domain.entity
 
 data class AccountBookEntity(
-    val userid: String? = null, //응답받을때 굳이 아이디를 받지 않아도 될 것 같아서 일단 null설정,
+    val id: String,
+    val userId: String? = null, // 응답 시 불필요
     val title: String,
     val category: String,
-    val imageUrl: List<String> = emptyList(),
-    val registerDate: String? = null, //요청
-    val year: Int? = null, //응답 요청할때 날자를 분리하면 서버에서 날짜 테이블로 저장, 응답할때 나눠진값 반환
-    val month: Int? = null, //응답 그런데 서버가 한명이니 상의해서 디바이스에서 계산할지 정해야할듯,
-    val day: Int? = null, //응답 그런데 5월 데이터만 불러오려면 서버에선 날짜 테이블 나누긴 해야할듯?
-    val dayName: String? = null, //응답
+    val imageUrl: List<String> = emptyList(), // 응답
+    // add 요청 이미지
+    val registerDateTime: String? = null, // 날짜 + 시각
+    val year: Int? = null, // 응답
+    val month: Int? = null, // 응답
+    val day: Int? = null, // 응답
+    val dayName: String? = null, // 응답 요일
     val revenue: Long? = null,
     val expense: Long? = null,
-    val totalRevenue: Long? = null,
-    val totalExpense: Long? = null,
-    val totalCost: Long? = null,
+    val totalRevenue: Long? = null, // 총 수입
+    val totalExpense: Long? = null, // 총 지출
+    val totalCost: Long? = null,  // 총 비용
 )
-//계산은 서버에서

--- a/app/src/main/java/kr/co/wdtt/nbdream/domain/repository/AccountBookRepository.kt
+++ b/app/src/main/java/kr/co/wdtt/nbdream/domain/repository/AccountBookRepository.kt
@@ -1,0 +1,21 @@
+package kr.co.wdtt.nbdream.domain.repository
+
+import kotlinx.coroutines.flow.Flow
+import kr.co.wdtt.nbdream.domain.entity.AccountBookEntity
+
+interface AccountBookRepository {
+    suspend fun getAccountBooks(
+        userId: String,
+        startDate: String,
+        endDate: String,
+        type: String, // "all", "revenue", "expense"
+        sortOrder: String, // "newest", "oldest"
+        category: String
+    ): Flow<List<AccountBookEntity>>
+
+    suspend fun createAccountBook(accountBook: AccountBookEntity): AccountBookEntity
+
+    suspend fun updateAccountBook(id: String, accountBook: AccountBookEntity): AccountBookEntity
+
+    suspend fun deleteAccountBook(id: String)
+}


### PR DESCRIPTION
## Issue
- #19 

## Overview
- AccountBookRepository : Account Book과 관련된 CRUD 기능 정의 
- AccountBookEntity : id 값 추가 
- AccountBookRepositoryImpl : AccountBookRepository를 구현해서 데이터의 CRUD 작업을 수행 
- AccountBookMapper : API 응답을 AccountBookEntity 리스트로 매핑  

## Screenshot (optional)
<img src="" width="300" />

## To Reviewers (optional)
(리뷰할 때 중점적으로 봐줬으면 좋을 점)
