### PR TITLE
Feat: Token저장 DataStore생성

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -66,6 +66,7 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.androidx.datastore.core.android)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
@@ -109,4 +110,7 @@ dependencies {
     // coil
     implementation(libs.coil)
     implementation(libs.coil.compose)
+
+    // data store
+    implementation(libs.androidx.datastore.preferences)
 }

--- a/app/src/main/java/kr/co/wdtt/core/data/source/local/SessionLocalDataSource.kt
+++ b/app/src/main/java/kr/co/wdtt/core/data/source/local/SessionLocalDataSource.kt
@@ -1,0 +1,23 @@
+package kr.co.wdtt.core.data.source.local
+
+import kotlinx.coroutines.flow.Flow
+
+interface SessionLocalDataSource {
+    suspend fun saveUserId(userId: String)
+
+    fun fetchUserId(): Flow<String?>
+
+    suspend fun updateAccessToken(
+        accessToken: String,
+    )
+
+    suspend fun updateRefreshToken(
+        refreshToken: String,
+    )
+
+    suspend fun getAccessToken(): String?
+
+    suspend fun getRefreshToken(): String?
+
+    suspend fun removeAll()
+}

--- a/app/src/main/java/kr/co/wdtt/core/local/SessionLocalDataSourceImpl.kt
+++ b/app/src/main/java/kr/co/wdtt/core/local/SessionLocalDataSourceImpl.kt
@@ -1,0 +1,60 @@
+package kr.co.wdtt.core.local
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
+import kr.co.wdtt.core.data.source.local.SessionLocalDataSource
+import javax.inject.Inject
+
+class SessionLocalDataSourceImpl @Inject constructor(
+    private val dataStore: DataStore<Preferences>
+) : SessionLocalDataSource {
+    override suspend fun saveUserId(userId: String) {
+        dataStore.edit { pref ->
+            pref[USER_ID] = userId
+        }
+    }
+
+    override fun fetchUserId(): Flow<String?> =
+        dataStore.data.map { pref ->
+            pref[USER_ID]
+    }
+
+    override suspend fun updateAccessToken(accessToken: String) {
+        dataStore.edit { pref ->
+            pref[ACCESS_TOKEN] = accessToken
+        }
+    }
+
+    override suspend fun updateRefreshToken(refreshToken: String) {
+        dataStore.edit { pref ->
+            pref[REFRESH_TOKEN] = refreshToken
+        }
+    }
+
+    override suspend fun getAccessToken(): String? =
+        dataStore.data.map { pref ->
+            pref[ACCESS_TOKEN]
+        }.firstOrNull()
+
+    override suspend fun getRefreshToken(): String? =
+        dataStore.data.map { pref ->
+            pref[REFRESH_TOKEN]
+        }.firstOrNull()
+
+    override suspend fun removeAll() {
+        dataStore.edit { pref ->
+            pref.clear()
+        }
+    }
+
+    companion object {
+        private val USER_ID = stringPreferencesKey("user_id")
+        private val ACCESS_TOKEN = stringPreferencesKey("access_token")
+        private val REFRESH_TOKEN = stringPreferencesKey("refresh_token")
+    }
+}

--- a/app/src/main/java/kr/co/wdtt/core/local/di/LocalModule.kt
+++ b/app/src/main/java/kr/co/wdtt/core/local/di/LocalModule.kt
@@ -1,0 +1,17 @@
+package kr.co.wdtt.core.local.di
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kr.co.wdtt.core.data.source.local.SessionLocalDataSource
+import kr.co.wdtt.core.local.SessionLocalDataSourceImpl
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class LocalModule {
+    @Singleton
+    @Binds
+    abstract fun bindLocalDataSource(local: SessionLocalDataSourceImpl): SessionLocalDataSource
+}

--- a/app/src/main/java/kr/co/wdtt/core/local/di/LocalServiceModule.kt
+++ b/app/src/main/java/kr/co/wdtt/core/local/di/LocalServiceModule.kt
@@ -1,0 +1,29 @@
+package kr.co.wdtt.core.local.di
+
+import android.content.Context
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.preferencesDataStoreFile
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import kr.co.wdtt.nbdream.BuildConfig
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+class LocalServiceModule {
+    @Singleton
+    @Provides
+    fun providePreferencesDataStore(@ApplicationContext context: Context) =
+        PreferenceDataStoreFactory.create (
+            corruptionHandler = ReplaceFileCorruptionHandler {
+                it.printStackTrace()
+                emptyPreferences()
+            },
+            produceFile = { context.preferencesDataStoreFile(BuildConfig.DATASTORE_NAME) }
+        )
+}

--- a/app/src/main/java/kr/co/wdtt/nbdream/ui/DreamApp.kt
+++ b/app/src/main/java/kr/co/wdtt/nbdream/ui/DreamApp.kt
@@ -2,7 +2,6 @@ package kr.co.wdtt.nbdream.ui
 
 import androidx.compose.runtime.Composable
 import kr.co.wdtt.nbdream.ui.calendar.CalendarScreen
-import kr.co.wdtt.nbdream.ui.home.HomeRoute
 
 @Composable
 fun DreamApp(){

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 agp = "8.4.1"
+datastorePreferences = "1.1.1"
 kotlin = "1.9.23"
 ksp = "1.9.23-1.0.20"
 hilt = "2.51.1"
@@ -30,12 +31,14 @@ serialization = "1.6.3"
 serialization-converter = "1.0.0"
 
 playServicesAuth = "21.2.0"
+datastoreCoreAndroid = "1.1.1"
 
 #v2All = "2.20.1"
 #v2Cert = "2.20.1"
 #v2User = "2.20.1"
 
 [libraries]
+androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastorePreferences" }
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycleLivedataKtx" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 
@@ -73,6 +76,7 @@ kotlinx-serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-
 kotlinx-serialization-converter = { module = "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter", version.ref = "serialization-converter" }
 
 play-services-auth = { module = "com.google.android.gms:play-services-auth", version.ref = "playServicesAuth" }
+androidx-datastore-core-android = { group = "androidx.datastore", name = "datastore-core-android", version.ref = "datastoreCoreAndroid" }
 
 #v2-all = { module = "com.kakao.sdk:v2-all", version.ref = "v2All" }
 #v2-cert = { module = "com.kakao.sdk:v2-cert", version.ref = "v2Cert" }


### PR DESCRIPTION
## Issue
- #83 

## Overview
saveUserId 유저 아이디 저장,
fetchUserId 저장된 유저 아이디 가져옴, 이거 통해서 스플래시 화면 진입점 정하면 됨

액세스 토큰, 유저가 서버로 진입하는 토큰 (cookie로 변경될 수 있음)

리프레시 토큰 (유통기간, 기간 지나면 진입 안됨, 새로 리프레시 해줘야함)
