### PR TITLE
Chore: gitignore 깃헙꺼 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,38 @@
 .externalNativeBuild
 .cxx
 local.properties
+
+## from GitHub android gitignore file
+# Gradle files
+.gradle/
+build/
+
+# Local configuration file (sdk path, etc)
+#local.properties
+
+# Log/OS Files
+*.log
+
+# Android Studio generated files and folders
+captures/
+.externalNativeBuild/
+.cxx/
+*.apk
+output.json
+
+# IntelliJ
+#*.iml
+.idea/
+misc.xml
+deploymentTargetDropDown.xml
+render.experimental.xml
+
+# Keystore files
+*.jks
+*.keystore
+
+# Google Services (e.g. APIs or Firebase)
+google-services.json
+
+# Android Profiling
+*.hprof


### PR DESCRIPTION
## Issue
- none

## Overview
dev 빌드했더니 Unversioned Files가 3600개가 생김.
.gitignore에 build/ 를 추가하면 되는데, 하는 김에 깃헙 저장소 만들 때 ignore를 android로 설정하면 자동으로 생기는 .gitignore의 내용을 복사해옴.
