### PR TITLE
Feat: DreamBottomSheetWithTextButtons 추가

### DIFF
--- a/core/ui/src/main/java/kr/co/ui/widget/DreamBottomSheetWithTextButtons.kt
+++ b/core/ui/src/main/java/kr/co/ui/widget/DreamBottomSheetWithTextButtons.kt
@@ -1,0 +1,76 @@
+package kr.co.ui.widget
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.material3.rememberStandardBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import kr.co.ui.theme.NBDreamTheme
+
+data class TextAndOnClick(
+    val text: String,
+    val onClick: () -> Unit,
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DreamBottomSheetWithTextButtons(
+    onDismissRequest: () -> Unit,
+    textAndOnClicks: List<TextAndOnClick>,
+    modifier: Modifier = Modifier,
+    sheetState: SheetState = rememberModalBottomSheetState(),
+//    scope: CoroutineScope = rememberCoroutineScope(),
+) {
+
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        modifier = modifier,
+        sheetState = sheetState,
+    ) {
+        for ((text, onClick) in textAndOnClicks) {
+            TextButton(
+                onClick = {
+                    onDismissRequest()
+                    onClick()
+
+//                // 바텀시트가 내려가고 나서 동작하게끔 하는 코드인데, 속도가 느려서 비활성화
+//                scope.launch { sheetState.hide() }.invokeOnCompletion {
+//                    if (!sheetState.isVisible) {
+//                        onDismissRequest()
+//                        onClick()
+//                    }
+//                }
+
+                },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(text)
+            }
+        }
+    }
+
+}
+
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Preview
+@Composable
+private fun DreamBottomSheetWithTextButtonsPreview() {
+    NBDreamTheme {
+        DreamBottomSheetWithTextButtons(
+            onDismissRequest = {},
+            textAndOnClicks = listOf(
+                TextAndOnClick("신고하기") {},
+                TextAndOnClick("수정하기") {},
+                TextAndOnClick("삭제하기") {},
+            ),
+            sheetState = rememberStandardBottomSheetState(),  // Preview 하려면 이거 넣어야 한다고 함.
+        )
+    }
+}


### PR DESCRIPTION
## Overview
텍스트와 실행할 람다식만으로 이루어진 간단한 바텀시트입니다.

간단하게 사용하기 좋아요.
디자인은 신경쓰지 않고 만들었습니다. 수정 환영...?

## Screenshot (optional)
![DreamBottomSheetWithTextButtons](https://github.com/WDTT-CodingClub/NBDream/assets/62335652/4296edd5-7a91-460a-b972-57703b953d6b)
